### PR TITLE
Filter out QTI performance spam

### DIFF
--- a/liblog/logprint.cpp
+++ b/liblog/logprint.cpp
@@ -197,7 +197,10 @@ static android_LogPriority filterPriForTag(AndroidLogFormat* p_format, const cha
  */
 int android_log_shouldPrintLine(AndroidLogFormat* p_format, const char* tag,
                                 android_LogPriority pri) {
-  return pri >= filterPriForTag(p_format, tag);
+  if (!strncmp(tag, "QCamera", 7) || !strncmp(tag, "ANDR-PERF-RESOURCE", 18) ||!strncmp(tag, "WCNSS_FILTER", 12) || !strncmp(tag, "mm-3a-core", 10) || !strncmp(tag, "AEC_PORT", 8) || !strncmp(tag, "mm-camera", 9) || !strncmp(tag, "GalleryDatab", 12))
+      return 0;
+  else
+      return pri >= filterPriForTag(p_format, tag);
 }
 
 AndroidLogFormat* android_log_format_new() {


### PR DESCRIPTION
If msm_performance disabled but we use qti perf HAL log will be full of spam about
"Failed to apply optimization...."

Change-Id: I0aaf73ea19b56f600fa03403019b843b18ab617a
Signed-off-by: DennySPB <dennyspb@gmail.com>

Former-commit-id: 2ed6c087bd6cc98118a0996712a3b5a9799052e4 [formerly 983fb5c59284816e12e972601dfa96024141f4d9]
Former-commit-id: 1681b5e4724948bddf77ee39a8482da1652c5d04
Signed-off-by: DennySPB <dennyspb@gmail.com>
Change-Id: I65da22783a103d12fa5795a8c4a3dae691817c18
Signed-off-by: Joey Huab <joey@evolution-x.org>

Former-commit-id: 3b1c02af50bbe5c14953bb5b6cae438dbd0dd93c
Signed-off-by: Joey Huab <joey@evolution-x.org>

Former-commit-id: 28abb1c5ef4b697ef0748dbb266ee655b15cfcb5